### PR TITLE
尝试修复PR preview的自动发布

### DIFF
--- a/.github/workflows/pr_preview.yml
+++ b/.github/workflows/pr_preview.yml
@@ -1,6 +1,6 @@
-name: Deploy branch preview (https://b.dsp-calc.pro)
+name: Deploy external PR preview (https://b.dsp-calc.pro)
 
-on: [push, workflow_dispatch]
+on: [pull_request]
 
 jobs:
   build:
@@ -23,4 +23,4 @@ jobs:
           zip -q -r ../dist.zip *
 
       - name: Deploy branch site (https://b.dsp-calc.pro)
-        run: "curl --fail --no-progress-meter --location 'https://publish.b.dsp-calc.pro/u?branch=${{ github.ref_name }}' --header 'Authorization: ${{ secrets.B_AUTH_TOKEN }}' --form 'file=@dist.zip'"
+        run: "curl --fail --no-progress-meter --location 'https://publish.b.dsp-calc.pro/external/pr?branch=${{ github.ref_name }}' --form 'file=@dist.zip'"


### PR DESCRIPTION
之前由于权限问题，其他repo提交过来的PR是不能发布到 b.dsp-calc.pro 上的，现在取消了这个权限限制。