### PR TITLE
Fix icon not displaying properly on Safari

### DIFF
--- a/src/icon.jsx
+++ b/src/icon.jsx
@@ -17,8 +17,6 @@ export function IconStyles() {
     function get_icon_style(game_name) {
         return `
 .icon-${game_name} {
-    vertical-align: bottom;
-    display: inline-block;
     background-image: url('icon/${game_name}.png');
     @supports (background-image: url('icon/${game_name}.webp')) {
         background-image: url('icon/${game_name}.webp');
@@ -42,6 +40,8 @@ function Icon({ item, size, game_name }) {
                 width: size, height: size,
                 backgroundPosition: `${bgx}px ${bgy}px`,
                 backgroundSize: `${tw}px ${th}px`,
+                display: "inline-block",
+                verticalAlign: "bottom",
             }}
         /></>;
     } catch {

--- a/src/icon.jsx
+++ b/src/icon.jsx
@@ -17,6 +17,8 @@ export function IconStyles() {
     function get_icon_style(game_name) {
         return `
 .icon-${game_name} {
+    vertical-align: bottom;
+    display: inline-block;
     background-image: url('icon/${game_name}.png');
     @supports (background-image: url('icon/${game_name}.webp')) {
         background-image: url('icon/${game_name}.webp');
@@ -35,13 +37,11 @@ function Icon({ item, size, game_name }) {
         const tw = total_width * scale, th = total_height * scale;
         const bgx = -x * scale, bgy = -y * scale;
 
-        return <><span className={`icon-${game_name}`}
+        return <><div className={`icon-${game_name}`}
             style={{
                 width: size, height: size,
                 backgroundPosition: `${bgx}px ${bgy}px`,
                 backgroundSize: `${tw}px ${th}px`,
-                display: "inline-block",
-                verticalAlign: "bottom",
             }}
         /></>;
     } catch {


### PR DESCRIPTION
Move `display` and `vertical-align` to icons' attribute `style` to make icons displaying properly on Safari.

![IMG](https://github.com/DSPCalculator/dsp-calc/assets/3337921/84b600ab-22b2-4655-aad2-e026f47b8fab)
