### PR TITLE
添加混带比例计算功能

### DIFF
--- a/src/settings.jsx
+++ b/src/settings.jsx
@@ -232,6 +232,14 @@ export function Settings() {
                 </td>
             </tr>
             <tr>
+                <td>混带计算</td>
+                <td className="ps-2">{settings.is_mix_vein_calculation ? "启用" : "禁用"}</td>
+                <td className="ps-2">
+                    <button onClick={e => change_bool_setting(e, "is_mix_vein_calculation")}>
+                        {settings.is_mix_vein_calculation ? "改为禁用" : "改为启用"}</button>
+                </td>
+            </tr>
+            <tr>
                 <td>精度位数</td>
                 <td className="ps-2">
                     <input type="number" value={settings.fixed_num} step={1} style={{maxWidth: '5em'}}


### PR DESCRIPTION
### 在当前的结算结果中添加混带的计算与比例功能，可以通过设置开启，如下图所示。
算是个人需要的功能吧，写得挺乱的。

![PixPin_2025-01-02_15-22-29](https://github.com/user-attachments/assets/65ab3c51-597a-46eb-98ca-3dff6b425199)

因为分拣器的最低速为30，于是可以将30作为1，也就是图中的份数
于是每个传送带，可以 除30 得出可以使用几份分拣器。