### PR TITLE
fix: broken dropdown list & sync batch preset UI with loaded scheme_data

### DIFF
--- a/css/App.css
+++ b/css/App.css
@@ -184,9 +184,11 @@ body > .p-3 {
 }
 
 /* 顶部面板：不参与滚动，自然高度 */
+/* 使用 clip 而非 auto：clip 不会创建滚动容器，
+   overflow-y 保持 visible，tooltip 可正常溢出到下方区域 */
 .app-top-panel {
     flex-shrink: 0;
-    overflow-x: auto;
+    overflow-x: clip;
 }
 
 /* 结果区域：填充剩余高度 */

--- a/src/batch_setting.jsx
+++ b/src/batch_setting.jsx
@@ -1,5 +1,5 @@
 import structuredClone from '@ungap/structured-clone';
-import {useContext, useState} from 'react';
+import {useContext} from 'react';
 import {CompactModeContext, GlobalStateContext, SchemeDataSetterContext} from './contexts';
 import {HorizontalMultiButtonSelect} from './recipe.jsx';
 import {pro_mode_class} from './result.jsx';
@@ -8,8 +8,17 @@ import {pro_mode_class} from './result.jsx';
 function FactorySelect({factory, list, icon_size}) {
     const global_state = useContext(GlobalStateContext);
     const set_scheme_data = useContext(SchemeDataSetterContext);
-    const [cur, set_cur] = useState(0);
     let game_data = global_state.game_data;
+    let scheme_data = global_state.scheme_data;
+
+    // 从 scheme_data 推导当前选中建筑（取该设施类型下第一个配方的建筑索引）
+    let cur = 0;
+    for (let i = 0; i < game_data.recipe_data.length; i++) {
+        if (game_data.recipe_data[i]["设施"] == factory) {
+            cur = scheme_data.scheme_for_recipe[i]["建筑"];
+            break;
+        }
+    }
 
     const options = list.map((data, idx) => ({
         value: idx, item_icon: data["名称"],
@@ -17,7 +26,6 @@ function FactorySelect({factory, list, icon_size}) {
     }));
 
     function set_factory(building) {
-        set_cur(building);
         // 取本设施类型选中建筑的名称，用于跨设施类型匹配
         const building_name = list[building]["名称"];
         set_scheme_data(old_scheme_data => {
@@ -43,10 +51,17 @@ export function BatchSetting() {
     const global_state = useContext(GlobalStateContext);
     const set_scheme_data = useContext(SchemeDataSetterContext);
     const compact_mode = useContext(CompactModeContext);
-    const [pro_num, set_pro_num] = useState(0);
-    const [pro_mode, set_pro_mode] = useState(0);
     let game_data = global_state.game_data;
+    let scheme_data = global_state.scheme_data;
     let proliferator_price = global_state.proliferator_price;
+
+    // 从 scheme_data 推导当前增产点数和增产模式（取第一个配方的值）
+    let pro_num = 0;
+    let pro_mode = 0;
+    if (scheme_data.scheme_for_recipe.length > 0) {
+        pro_num = scheme_data.scheme_for_recipe[0]["增产点数"];
+        pro_mode = scheme_data.scheme_for_recipe[0]["增产模式"];
+    }
 
     const is_mobile = compact_mode === "mobile";
     const mob_icon = is_mobile ? 22 : undefined;
@@ -84,7 +99,6 @@ export function BatchSetting() {
     });
 
     function change_pro_num(pro_num) {
-        set_pro_num(pro_num);
         set_scheme_data(old_scheme_data => {
             let scheme_data = structuredClone(old_scheme_data);
             for (var i = 0; i < game_data.recipe_data.length; i++) {
@@ -95,7 +109,6 @@ export function BatchSetting() {
     }
 
     function change_pro_mode(pro_mode) {
-        set_pro_mode(pro_mode);
         set_scheme_data(old_scheme_data => {
             let scheme_data = structuredClone(old_scheme_data);
             for (var i = 0; i < game_data.recipe_data.length; i++) {

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -5,7 +5,8 @@ import {Header} from './header.jsx';
 import {IconStyles} from './icon.jsx';
 import {ThemeProvider} from './ThemeContext.jsx';
 
-import 'bootstrap/dist/js/bootstrap.min.js';
+// Not using 'bootstrap/dist/js/bootstrap.min.js' here, because it breaks dropdown-list
+import 'bootstrap';
 
 import '../css/styles.scss';
 // app-specific CSS


### PR DESCRIPTION
## Summary
- **Fix broken dropdown list**: Replace `bootstrap/dist/js/bootstrap.min.js` with `bootstrap` entry point, which resolves dropdown menus not working correctly.
- **Sync batch preset UI with loaded scheme_data**: Remove local `useState` for building selection, proliferator number, and proliferator mode in `BatchSetting` / `FactorySelect`. Instead, derive these values directly from `scheme_data`, so the batch preset UI stays in sync when a saved scheme is loaded.