### PR TITLE
feat(layout): 中窄模式下将侧面板折叠为弹出覆盖面板

### DIFF
--- a/css/App.css
+++ b/css/App.css
@@ -106,15 +106,15 @@
 
 .fast-tooltip:hover::after {
     z-index: 10000;
-    position: absolute;
+    position: fixed;
     display: block;
     content: attr(data-tooltip);
-    top: 120%;
-    left: 62%;
     width: max-content;
     background-color: #333;
     color: white;
     padding: .15em .4em;
+    margin-top: .3em;
+    pointer-events: none;
 }
 
 .border-between {
@@ -232,12 +232,38 @@ body > .p-3 {
 }
 
 /* ============================================================
-   响应式辅助类
-   ============================================================ */
+    响应式辅助类
+    ============================================================ */
 
 /* compact-show: 默认隐藏，在 compact 及以下模式显示 */
 .compact-show {
     display: none !important;
+}
+
+/* 弹出面板按钮：默认隐藏，仅 narrow/mobile 下显示 */
+.summary-popup-btn {
+    display: none !important;
+}
+
+/* 弹出面板按钮高度：匹配 input-group-sm 内按钮的高度
+   Bootstrap 5 input-group-sm 的 .form-control 高度公式:
+   line-height(1.5) * font-size(.875rem) + padding-y(.25rem*2) + border(1px*2) */
+.summary-popup-btn-item {
+    height: calc(1.5 * .875rem + .5rem + 2px);
+}
+
+/* 弹出面板 Modal 内容区布局 */
+.summary-modal-body {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1rem;
+    align-items: flex-start;
+}
+
+/* 确保弹出面板 Modal 内的 tooltip 不被裁剪、不产生滚动条
+   Bootstrap 的 .modal-content 默认设了 overflow: hidden，必须用 !important 覆盖 */
+.mw-fit .modal-content {
+    overflow: visible !important;
 }
 
 /* 预估电力单位：默认显示末尾版，隐藏括号版 */
@@ -328,9 +354,20 @@ body > .p-3 {
         height: 22px !important;
     }
 
-    /* 总结面板最大宽度放宽（窄屏每个字符都珍贵） */
+    /* 隐藏右侧总结面板，改为弹出按钮 */
     .result-summary-scroll {
-        max-width: 260px;
+        display: none !important;
+    }
+
+    /* 结果表格扩展至全宽 */
+    .result-table-scroll {
+        flex: 1 1 auto;
+        width: 100%;
+    }
+
+    /* 显示弹出面板按钮 */
+    .summary-popup-btn {
+        display: inline-flex !important;
     }
 }
 
@@ -373,13 +410,7 @@ body > .p-3 {
 
     /* 下半：总结面板 */
     .result-summary-scroll {
-        flex-shrink: 0;
-        width: 100%;
-        max-width: 100%;
-        max-height: 38vh;
-        overflow-y: auto;
-        overflow-x: auto;
-        padding-top: 0.5rem;
+        display: none !important;
     }
 
     /* 移动端表格字号缩小 */

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -158,6 +158,8 @@ function UserSettings({show}) {
 function AppWithContexts() {
     const game_info = useContext(GameInfoContext);
     const [misc_show, set_misc_show] = useState(false);
+    const [show_ore_popup, set_show_ore_popup] = useState(false);
+    const [show_building_popup, set_show_building_popup] = useState(false);
     const [needs_list, set_needs_list] = useState({});
     useEffect(() => {
         set_needs_list({});
@@ -196,12 +198,16 @@ function AppWithContexts() {
             {/*采矿参数&其他设置*/}
             <UserSettings show={misc_show}/>
             {/*添加需求、批量预设*/}
-            <NeedsList needs_list={needs_list} set_needs_list={set_needs_list}/>
+            <NeedsList needs_list={needs_list} set_needs_list={set_needs_list}
+                       set_show_ore_popup={set_show_ore_popup}
+                       set_show_building_popup={set_show_building_popup}/>
             <BatchSetting/>
         </div>
         {/* 结果区域：填充剩余高度，独立滚动 */}
         <div className="app-result-area">
-            <Result needs_list={needs_list} set_needs_list={set_needs_list}/>
+            <Result needs_list={needs_list} set_needs_list={set_needs_list}
+                    show_ore_popup={show_ore_popup} set_show_ore_popup={set_show_ore_popup}
+                    show_building_popup={show_building_popup} set_show_building_popup={set_show_building_popup}/>
         </div>
     </div>;
 }

--- a/src/batch_setting.jsx
+++ b/src/batch_setting.jsx
@@ -1,4 +1,4 @@
-import {useContext, useState} from 'react';
+import {useContext} from 'react';
 import {CompactModeContext, GlobalStateContext, SchemeDataSetterContext} from './contexts';
 import {HorizontalMultiButtonSelect} from './recipe.jsx';
 import {pro_mode_class} from './result.jsx';

--- a/src/needs_list.jsx
+++ b/src/needs_list.jsx
@@ -1,5 +1,5 @@
 import {useContext, useEffect, useRef, useState} from 'react';
-import {FaRegSave, FaRegFolderOpen, FaTrash, FaPlusCircle, FaPlusSquare} from 'react-icons/fa';
+import {FaRegSave, FaRegFolderOpen, FaTrash, FaPlusCircle, FaPlusSquare, FaGem, FaIndustry} from 'react-icons/fa';
 import {GameInfoContext, GlobalStateContext, SettingsSetterContext} from './contexts';
 import {ItemIcon} from './icon';
 import {ItemSelect} from './item_select';
@@ -21,7 +21,7 @@ function get_item_data(game_data) {
     return item_data;
 }
 
-export function NeedsList({needs_list, set_needs_list}) {
+export function NeedsList({needs_list, set_needs_list, set_show_ore_popup, set_show_building_popup}) {
     const global_state = useContext(GlobalStateContext);
     const count_ref = useRef(60);
     const set_settings = useContext(SettingsSetterContext);
@@ -78,7 +78,7 @@ export function NeedsList({needs_list, set_needs_list}) {
     const is_min = global_state.settings.is_time_unit_minute;
 
     return <>
-        <div className="w-fit mt-3 d-flex align-items-center row-gap-1 flex-wrap">
+        <div className="mt-3 d-flex align-items-center row-gap-1 flex-wrap">
             <small className="me-3 fw-bold text-nowrap">添加需求</small>
             <div className="input-group input-group-sm w-fit d-inline-flex me-5">
                 <input type="text" className="form-control" style={{width: "6em"}} ref={count_ref} defaultValue={60}/>
@@ -100,6 +100,20 @@ export function NeedsList({needs_list, set_needs_list}) {
                     {needs_doms}
                 </div>
             }
+
+            {/* 弹出面板按钮（narrow/mobile 下显示，compact/full 下 CSS 隐藏） */}
+            <div className="summary-popup-btn ms-auto d-inline-flex gap-1">
+                <button className="btn btn-sm btn-outline-secondary d-inline-flex align-items-center gap-1 summary-popup-btn-item"
+                        onClick={() => set_show_ore_popup(s => !s)}
+                        title="原矿化列表 & 多余产物">
+                    <FaGem/>
+                </button>
+                <button className="btn btn-sm btn-outline-secondary d-inline-flex align-items-center gap-1 summary-popup-btn-item"
+                        onClick={() => set_show_building_popup(s => !s)}
+                        title="建筑统计 & 预估电力">
+                    <FaIndustry/>
+                </button>
+            </div>
         </div>
     </>;
 }

--- a/src/result.jsx
+++ b/src/result.jsx
@@ -1,4 +1,6 @@
-import {useContext, useMemo, useState, useEffect} from 'react';
+import {useContext, useMemo, useState, useEffect, useRef} from 'react';
+import {createPortal} from 'react-dom';
+import {Modal} from 'bootstrap';
 import {CompactModeContext, GlobalStateContext, SchemeDataSetterContext, SettingsSetterContext} from './contexts';
 import {ItemIcon} from './icon';
 import {NplRows} from './natural_production_line';
@@ -158,7 +160,7 @@ const isEqual = (obj1, obj2) => {
     return true;
 };
 
-export function Result({needs_list, set_needs_list}) {
+export function Result({needs_list, set_needs_list, show_ore_popup, set_show_ore_popup, show_building_popup, set_show_building_popup}) {
     const global_state = useContext(GlobalStateContext);
     const set_scheme_data = useContext(SchemeDataSetterContext);
     const set_settings = useContext(SettingsSetterContext);
@@ -166,6 +168,59 @@ export function Result({needs_list, set_needs_list}) {
     const is_compact = compact_mode !== "full";
     const is_mobile = compact_mode === "mobile";
     const mob_icon = is_mobile ? 20 : undefined;   // 总结面板/主图标
+
+    // Refs for Bootstrap Modal instances
+    const ore_modal_ref = useRef(null);
+    const ore_modal_instance = useRef(null);
+    const building_modal_ref = useRef(null);
+    const building_modal_instance = useRef(null);
+
+    // Initialize Bootstrap Modal instances
+    useEffect(() => {
+        if (ore_modal_ref.current) {
+            ore_modal_instance.current = new Modal(ore_modal_ref.current);
+            ore_modal_ref.current.addEventListener('hidden.bs.modal', () => {
+                set_show_ore_popup(false);
+            });
+        }
+    }, [ore_modal_ref]); // eslint-disable-line react-hooks/exhaustive-deps
+
+    useEffect(() => {
+        if (building_modal_ref.current) {
+            building_modal_instance.current = new Modal(building_modal_ref.current);
+            building_modal_ref.current.addEventListener('hidden.bs.modal', () => {
+                set_show_building_popup(false);
+            });
+        }
+    }, [building_modal_ref]); // eslint-disable-line react-hooks/exhaustive-deps
+
+    // Show/hide Modal A based on show_ore_popup prop
+    useEffect(() => {
+        if (!ore_modal_instance.current) return;
+        if (show_ore_popup) {
+            ore_modal_instance.current.show();
+        } else {
+            ore_modal_instance.current.hide();
+        }
+    }, [show_ore_popup]);
+
+    // Show/hide Modal B based on show_building_popup prop
+    useEffect(() => {
+        if (!building_modal_instance.current) return;
+        if (show_building_popup) {
+            building_modal_instance.current.show();
+        } else {
+            building_modal_instance.current.hide();
+        }
+    }, [show_building_popup]);
+
+    // Auto-close both modals when exiting narrow/mobile mode
+    useEffect(() => {
+        if (compact_mode !== "narrow" && compact_mode !== "mobile") {
+            set_show_ore_popup(false);
+            set_show_building_popup(false);
+        }
+    }, [compact_mode, set_show_ore_popup, set_show_building_popup]);
     const mob_btn_icon = is_mobile ? 18 : undefined; // 表格内按钮图标
     // const [result_dict, set_result_dict] = useState(global_state.calculate());
     let game_data = global_state.game_data;
@@ -533,6 +588,7 @@ export function Result({needs_list, set_needs_list}) {
         </div>
         {/* 右侧：总结面板独立滚动区域 */}
         <div className="result-summary-scroll">
+        {compact_mode !== "narrow" && compact_mode !== "mobile" &&
         <div className="d-flex flex-column gap-2 summary-panel-content">
 
             {/* 第一列：原矿化列表 + 多余产物（mobile 时还包含预估电力） */}
@@ -588,17 +644,16 @@ export function Result({needs_list, set_needs_list}) {
                                 {rawMaterials.map(([item, amount]) => (
                                     <tr key={item}>
                                         <td className="d-flex align-items-center text-nowrap">
-                                            <ItemIcon item={item} tooltip={false} size={is_mobile ? 18 : 24}/>
-                                            <small className="ms-1 compact-hide-text">{item}</small>
+                                            <span className="ms-auto me-1 compact-hide-text">{item}</span>
+                                            <ItemIcon item={item} tooltip={false} size={mob_icon}/>
                                         </td>
                                         <td className="ps-2 text-nowrap">
-                                            <small>
-                                                <ValueWithDifference
-                                                    currentValue={amount}
-                                                    previousValue={historyValues?.[1]?.rawMaterials?.[item]}
-                                                    key={`raw-material-${item}`}
-                                                />/{time_tick === 60 ? 'min' : 'sec'}
-                                            </small>
+                                            {'x '}
+                                            <ValueWithDifference
+                                                currentValue={amount}
+                                                previousValue={historyValues?.[1]?.rawMaterials?.[item]}
+                                                key={`raw-material-${item}`}
+                                            />/{time_tick === 60 ? 'min' : 'sec'}
                                         </td>
                                     </tr>
                                 ))}
@@ -637,7 +692,114 @@ export function Result({needs_list, set_needs_list}) {
                     </span>
                     <span className="energy-cost-unit-trailing">MW</span>
                 </span>}
+        </div>}
         </div>
-        </div>
+
+        {/* Modal A: 原矿化列表 + 多余产物 */}
+        {createPortal(
+            <div ref={ore_modal_ref} className="modal" tabIndex="-1">
+                <div className="modal-dialog mw-fit">
+                    <div className="modal-content bg-body flex-column" style={{"--bs-bg-opacity": 0.85}}>
+                        <div className="modal-header border-secondary">
+                            <h6 className="modal-title">原矿 &amp; 多余产物</h6>
+                            <button type="button" className="btn-close" data-bs-dismiss="modal"/>
+                        </div>
+                        <div className="modal-body summary-modal-body">
+                            {mineralize_doms.length > 0 &&
+                                <fieldset className="w-fit">
+                                    <legend><small>原矿化列表</small></legend>
+                                    <div className="d-flex flex-wrap align-items-center">
+                                        {mineralize_doms}
+                                        <button className="ms-2 btn btn-sm btn-outline-danger text-nowrap"
+                                                onClick={clear_mineralize_list}>清空
+                                        </button>
+                                    </div>
+                                </fieldset>
+                            }
+                            {surplus_doms.length > 0 &&
+                                <fieldset className="w-fit">
+                                    <legend><small>多余产物</small></legend>
+                                    {surplus_doms}
+                                </fieldset>}
+                        </div>
+                    </div>
+                </div>
+            </div>
+            , document.body)}
+
+        {/* Modal B: 原矿输入总需求 + 建筑统计 + 预估电力 */}
+        {createPortal(
+            <div ref={building_modal_ref} className="modal" tabIndex="-1">
+                <div className="modal-dialog mw-fit">
+                    <div className="modal-content bg-body flex-column" style={{"--bs-bg-opacity": 0.85}}>
+                        <div className="modal-header border-secondary">
+                            <h6 className="modal-title">建筑 &amp; 需求</h6>
+                            <button type="button" className="btn-close" data-bs-dismiss="modal"/>
+                        </div>
+                        <div className="modal-body summary-modal-body">
+                            {/* 原矿输入总需求 */}
+                            {(() => {
+                                const rawMaterials = Object.entries(result_dict).filter(([item]) => isRawMaterial(item));
+                                return rawMaterials.length > 0 && (
+                                    <fieldset className="w-fit">
+                                        <legend><small>原矿输入总需求</small></legend>
+                                        <table>
+                                            <tbody>
+                                                {rawMaterials.map(([item, amount]) => (
+                                                    <tr key={item}>
+                                                        <td className="d-flex align-items-center text-nowrap">
+                                                            <span className="ms-auto me-1 compact-hide-text">{item}</span>
+                                                            <ItemIcon item={item} tooltip={false} size={mob_icon}/>
+                                                        </td>
+                                                        <td className="ps-2 text-nowrap">
+                                                            {'x '}
+                                                            <ValueWithDifference
+                                                                currentValue={amount}
+                                                                previousValue={historyValues?.[1]?.rawMaterials?.[item]}
+                                                                key={`raw-material-${item}`}
+                                                            />/{time_tick === 60 ? 'min' : 'sec'}
+                                                        </td>
+                                                    </tr>
+                                                ))}
+                                            </tbody>
+                                        </table>
+                                    </fieldset>
+                                );
+                            })()}
+                            {/* 建筑统计 */}
+                            {building_rows.length > 0 &&
+                                <fieldset className="w-fit">
+                                    <legend><small>建筑统计</small></legend>
+                                    <table>
+                                        <tbody>{building_rows}</tbody>
+                                    </table>
+                                </fieldset>}
+                        </div>
+                        {/* 预估电力 — 固定在底部 */}
+                        {building_rows.length > 0 &&
+                            <div className="modal-footer border-secondary justify-content-start">
+                                <span className="d-inline-flex gap-1 text-nowrap energy-cost-display">
+                                    <span className="me-1">预估电力<span className="energy-cost-unit-inline"> (MW)</span></span>
+                                    <span className="fast-tooltip" data-tooltip="不包含采集设备">
+                                        <ValueWithDifference
+                                            currentValue={energy_cost}
+                                            previousValue={historyValues?.[1]?.energyCost}
+                                            key="energy-cost"
+                                        />
+                                    </span><span className="energy-cost-separator">/</span>
+                                    <span className="fast-tooltip" data-tooltip="包含采集设备">
+                                        <ValueWithDifference
+                                            currentValue={energy_cost + miner_energy_cost}
+                                            previousValue={historyValues?.[1]?.totalEnergyCost}
+                                            key="total-energy-cost"
+                                        />
+                                    </span>
+                                    <span className="energy-cost-unit-trailing">MW</span>
+                                </span>
+                            </div>}
+                    </div>
+                </div>
+            </div>
+            , document.body)}
     </div>;
 }


### PR DESCRIPTION
## Summary

在 narrow (768-1023px) 和 mobile (<768px) 模式下，隐藏右侧/底部的总结面板，改为两个工具栏按钮触发的 Modal 弹出面板，使结果表格占满全部可用宽度。

## Changes

- **CSS**: narrow/mobile 下隐藏 `.result-summary-scroll`，扩展 `.result-table-scroll` 至全宽；添加 `.summary-popup-btn` 按钮显隐规则
- **App.jsx**: 添加 `show_ore_popup` / `show_building_popup` toggle 状态
- **needs_list.jsx**: 在添加需求工具栏右侧添加两个弹出按钮（FaGem / FaIndustry），仅 narrow/mobile 下可见
- **result.jsx**: 通过 `createPortal` 渲染两个 Bootstrap Modal：
  - Modal A（原矿）：原矿化列表 + 多余产物
  - Modal B（建筑）：原矿输入总需求 + 建筑统计 + 预估电力
- 窗口 resize 跨越断点时 Modal 自动关闭
- Modal 背景使用 `bg-body` 跟随亮色/暗色主题（item_select 保持 `bg-dark`）
- `.fast-tooltip` 改为 `position: fixed` 避免在 overflow 容器内被裁剪
- 统一原矿输入总需求与建筑统计面板的图标大小和布局顺序

## Unaffected

- compact (≥1024px) 和 full (≥1400px) 模式完全不受影响
- 面板内所有交互（unmineralize、清空、避免溢出）在 Modal 内正常工作
